### PR TITLE
Added MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+README.rst


### PR DESCRIPTION
When downloading the tarball from pypi and extracting the contents there is no README.rst file. This makes it impossible to build another source distribution that is installable (because of setup.py's dependency on the README.rst fiel existing). With the addition of the MANIFEST.in file the README.rst will be included.