### PR TITLE
Update Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 language: python
 
 python:
+    - 2.6
     - 2.7
     - 3.4
     - 3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,18 @@ sudo: false
 language: python
 
 python:
-    - 2.6
     - 2.7
     - 3.4
     - 3.5
+    - 3.6
     - pypy
     - pypy3
 
 matrix:
     include:
-        - python: 3.5
+        - python: 3.6
           env: STYLE='code'
-        - python: 3.5
+        - python: 3.6
           env: STYLE='docs'
 
 install:

--- a/README.rst
+++ b/README.rst
@@ -4,8 +4,8 @@ jdcal
 .. _TPM: http://www.sal.wisc.edu/~jwp/astro/tpm/tpm.html
 .. _Jeffrey W. Percival: http://www.sal.wisc.edu/~jwp/
 .. _IAU SOFA: http://www.iausofa.org/
-.. _pip: http://pypi.python.org/pypi/pip
-.. _easy_install: packages.python.org/distribute/easy_install.html
+.. _pip: https://pypi.python.org/pypi/pip
+.. _easy_install: https://setuptools.readthedocs.io/en/latest/easy_install.html
 
 .. image:: https://travis-ci.org/phn/jdcal.svg?branch=master
     :target: https://travis-ci.org/phn/jdcal
@@ -47,7 +47,7 @@ Examples
 --------
 
 Some examples are given below. For more information see
-http://oneau.wordpress.com/jdcal/.
+https://oneau.wordpress.com/2011/08/30/jdcal/.
 
 Gregorian calendar:
 

--- a/jdcal.py
+++ b/jdcal.py
@@ -36,7 +36,7 @@ inspired by the IAU SOFA C library.
 
 :author: Prasanth Nair
 :contact: prasanthhn@gmail.com
-:license: BSD (http://www.opensource.org/licenses/bsd-license.php)
+:license: BSD (https://opensource.org/licenses/bsd-license.php)
 """
 from __future__ import division
 from __future__ import print_function

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,14 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Topic :: Scientific/Engineering :: Astronomy',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: Implementation :: CPython',
+        'Programming Language :: Python :: Implementation :: PyPy',
     ],
     py_modules=["jdcal"]
 )

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     license='BSD',
     author="Prasanth Nair",
     author_email="prasanthhn@gmail.com",
-    url='http://github.com/phn/jdcal',
+    url='https://github.com/phn/jdcal',
     classifiers=[
         'Development Status :: 6 - Mature',
         'Intended Audience :: Science/Research',

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
 project = jdcal
-envlist = py26,py27,py34,py35,pypy,pypy3,codestyle,docstyle
+envlist = py27, py34, py35, pypy, pypy3, codestyle, docstyle
 
 [testenv]
 deps = pytest
-commands = py.test
+commands = pytest
 
 [testenv:codestyle]
 deps = pycodestyle


### PR DESCRIPTION
Python 3.6 was released on 2016-12-23, so add it.

Python 2.6 reached EOL on 2013-10-29, and no longer receives security updates.

![image](https://user-images.githubusercontent.com/1324225/35687862-7cb54006-0778-11e8-96c2-cc4e04aa0366.png)

https://en.wikipedia.org/wiki/CPython#Version_history

Also, whilst we're here, update some HTTP links to HTTPS.