### PR TITLE
Add universal wheel support

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,7 @@
+UNRELEASED
+
+    Add universal wheel distribution.
+
 jdcal 1.3
 
     Use setuptools instead of distutils. This enables package managers to

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[bdist_wheel]
+universal = 1
+
+[metadata]
+license_file = LICENSE.txt


### PR DESCRIPTION
For information on Python wheels, see https://pythonwheels.com/

Advantages of wheels

- Faster installation for pure python packages
- Avoids arbitrary code execution for installation by avoiding `setup.py`
- Allows better caching for testing and continuous integration
- Creates `.pyc` files as part of installation to ensure they match the python interpreter used
- More consistent installs across platforms and machines

When uploading to PyPI, upload the universal wheel with:

```
$ python setup.py sdist bdist_wheel upload
```

The wheel includes a copy of `LICENSE.txt` in the distribution.