### PR TITLE
Trim trailing white space throughout the project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,4 +43,3 @@ script:
       else
         py.test
       fi
-

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,7 +9,7 @@ jdcal 1.2
 
     No change in functionalities.
 
-    Added test_jdcal.py; removed test functions from jdcal.py. 
+    Added test_jdcal.py; removed test functions from jdcal.py.
 
     Added CHANGELOG.txt.
 
@@ -17,9 +17,9 @@ jdcal 1.2
 
 
 jdcal 1.0.1
-    
-    This version has exactly the same code as in jdcal 1.0, except the 
+
+    This version has exactly the same code as in jdcal 1.0, except the
     tar file has LICENSE.txt in it.
 
-    See issue #5 (https://github.com/phn/jdcal/issues/5) for why version this 
+    See issue #5 (https://github.com/phn/jdcal/issues/5) for why version this
     was created.

--- a/README.rst
+++ b/README.rst
@@ -148,4 +148,3 @@ Released under BSD; see LICENSE.txt.
 
 For comments and suggestions, email to user `prasanthhn` in the `gmail.com`
 domain.
-


### PR DESCRIPTION
Many editors clean up trailing white space on save. By removing it all in one go, it helps keep future diffs cleaner by avoiding spurious white space changes on unrelated lines.