### PR TITLE
Travis CI: Drop support for Python 3.4 because it is now EOL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,47 +1,24 @@
-sudo: false
-
 language: python
 dist: xenial
 cache: pip
 
 python:
-    - 2.7
-    - 3.4
-    - 3.5
-    - 3.6
-    - 3.7
-    - pypy2.7-6.0
-    - pypy3.5-6.0
+   - 2.7
+   - 3.5
+   - 3.6
+   - 3.7
+   - pypy2.7-6.0
+   - pypy3.5-6.0
 
 matrix:
-    include:
-        - python: 3.7
-          env: STYLE='code'
-        - python: 3.7
-          env: STYLE='docs'
+   include:
+       - name: code
+         python: 3.7
+         install: pip install pycodestyle
+         script: pycodestyle --verbose jdcal.py test_jdcal.py
+       - name: docs
+         python: 3.7
+         install: pip install pydocstyle
+         script: pydocstyle --verbose jdcal.py test_jdcal.py
 
-install:
-    - |
-      if [[ $STYLE ]]; then
-        if [[ $STYLE == 'code' ]]; then
-            pip install pycodestyle
-        fi
-        if [[ $STYLE == 'docs' ]]; then
-            pip install pydocstyle
-        fi
-      else
-        pip install -U pytest
-      fi
-
-script:
-    - |
-      if [[ $STYLE ]]; then
-        if [[ $STYLE == 'code' ]]; then
-            pycodestyle --verbose jdcal.py test_jdcal.py
-        fi
-        if [[ $STYLE == 'docs' ]]; then
-            pydocstyle --verbose jdcal.py test_jdcal.py
-        fi
-      else
-        py.test
-      fi
+script: py.test

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,22 +3,22 @@ dist: xenial
 cache: pip
 
 python:
-   - 2.7
-   - 3.5
-   - 3.6
-   - 3.7
-   - pypy2.7-6.0
-   - pypy3.5-6.0
+    - 2.7
+    - 3.5
+    - 3.6
+    - 3.7
+    - pypy2.7-6.0
+    - pypy3.5-6.0
 
 matrix:
-   include:
-       - name: code
-         python: 3.7
-         install: pip install pycodestyle
-         script: pycodestyle --verbose jdcal.py test_jdcal.py
-       - name: docs
-         python: 3.7
-         install: pip install pydocstyle
-         script: pydocstyle --verbose jdcal.py test_jdcal.py
+    include:
+        - name: code
+          python: 3.7
+          install: pip install pycodestyle
+          script: pycodestyle --verbose jdcal.py test_jdcal.py
+        - name: docs
+          python: 3.7
+          install: pip install pydocstyle
+          script: pydocstyle --verbose jdcal.py test_jdcal.py
 
 script: py.test


### PR DESCRIPTION
Python 3.4 is End of Life: https://devguide.python.org/devcycle/#end-of-life-branches

[Travis are now recommending removing the __sudo__ tag](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).

"_If you currently specify __sudo: false__ in your __.travis.yml__, we recommend removing that configuration_"

Use the matrix to avoid complex base if / then / fi logic.

Suggestion: __flake8__ is a more powerful superset of __pycodestyle__.