### PR TITLE
Use builtin mod operator

### DIFF
--- a/jdcal.py
+++ b/jdcal.py
@@ -55,9 +55,9 @@ def ipart(x):
 
 def is_leap(year):
     """Leap year or not in the Gregorian calendar."""
-    x = math.fmod(year, 4)
-    y = math.fmod(year, 100)
-    z = math.fmod(year, 400)
+    x = year % 4
+    y = year % 100
+    z = year % 400
 
     # Divisible by 4 and,
     # either not divisible by 100 or divisible by 400.


### PR DESCRIPTION
The Python docs recommend using the builtin mod operator (%) for
integers.

https://docs.python.org/3/library/math.html#math.fmod

> For this reason, function fmod() is generally preferred when working
> with floats, while Python’s x % y is preferred when working with
> integers.