### PR TITLE
Simplify Travis CI configuration and add testing for Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,47 +1,25 @@
-sudo: false
-
 language: python
-dist: xenial
 cache: pip
 
 python:
-    - 2.7
-    - 3.4
-    - 3.5
-    - 3.6
-    - 3.7
-    - pypy2.7-6.0
-    - pypy3.5-6.0
+  - 3.8
+  - 3.7
+  - 3.6
+  - 3.5
+  - 3.4
+  - 2.7
+  - pypy3
+  - pypy
+
+env:
+  global:
+    - TOXENV=py
 
 matrix:
-    include:
-        - python: 3.7
-          env: STYLE='code'
-        - python: 3.7
-          env: STYLE='docs'
+  include:
+    - env: TOXENV=codestyle
+    - env: TOXENV=docstyle
 
-install:
-    - |
-      if [[ $STYLE ]]; then
-        if [[ $STYLE == 'code' ]]; then
-            pip install pycodestyle
-        fi
-        if [[ $STYLE == 'docs' ]]; then
-            pip install pydocstyle
-        fi
-      else
-        pip install -U pytest
-      fi
+install: pip install tox
 
-script:
-    - |
-      if [[ $STYLE ]]; then
-        if [[ $STYLE == 'code' ]]; then
-            pycodestyle --verbose jdcal.py test_jdcal.py
-        fi
-        if [[ $STYLE == 'docs' ]]; then
-            pydocstyle --verbose jdcal.py test_jdcal.py
-        fi
-      else
-        py.test
-      fi
+script: tox

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 project = jdcal
-envlist = py27, py34, py35, py36, py37, pypy, pypy3, codestyle, docstyle
+envlist = py{27,34,35,36,37,38,py,py3}, codestyle, docstyle
 
 [testenv]
 deps = pytest


### PR DESCRIPTION
Can drop deprecated sudo option:

https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

Xenial is now the default, can drop the dist option:

https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment

Use tox as the single entry point to run tests. This unifies Travis
testing with local testing.

Use the shorter alias pypy3 & pypy to test against the most recently
supported PyPy versions.

Test against Python 3.8 and add the trove classifier.