### PR TITLE
Fix the data type for jd1 and jd2 in docstrings

### DIFF
--- a/jdcal.py
+++ b/jdcal.py
@@ -199,7 +199,7 @@ def jd2gcal(jd1, jd2):
 
     Parameters
     ----------
-    jd1, jd2: int
+    jd1, jd2: float
         Sum of the two numbers is taken as the given Julian date. For
         example `jd1` can be the zero point of MJD (MJD_0) and `jd2`
         can be the MJD of the date and time. But any combination will
@@ -365,7 +365,7 @@ def jd2jcal(jd1, jd2):
 
     Parameters
     ----------
-    jd1, jd2: int
+    jd1, jd2: float
         Sum of the two numbers is taken as the given Julian date. For
         example `jd1` can be the zero point of MJD (MJD_0) and `jd2`
         can be the MJD of the date and time. But any combination will


### PR DESCRIPTION
It is a really minor issue but it trigger a warning in my IDE so I would appreciate a lot if it could merged.

P.S. thanks a lot for this library, I find it very useful and well done.