### PR TITLE
Adding ppc64le architecture support on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,42 @@ matrix:
       env: TOXENV=py34
     - python: 2.7
       env: TOXENV=py27
-      
-install: pip install tox
+    # Adding ppc64le jobs
+    - python: 3.8
+      arch: ppc64le
+      env: TOXENV=codestyle
+    - python: 3.8
+      arch: ppc64le
+      env: TOXENV=docstyle
+    - python: 3.8
+      arch: ppc64le
+      env: TOXENV=py38
+    - python: 3.7
+      arch: ppc64le
+      env: TOXENV=py37
+    - python: 3.6
+      arch: ppc64le
+      env: TOXENV=py36
+    - python: 3.5
+      arch: ppc64le
+      env: TOXENV=py35
+    - python: 3.4
+      arch: ppc64le
+      env: TOXENV=py34
+  exclude:
+    - arch: ppc64le
+      python: pypy
+    - arch: ppc64le
+      python: pypy3
+
+before_install:
+  - | 
+   if [[ "$TRAVIS_CPU_ARCH" == "ppc64le" ]]; then
+     sudo chown -Rv $USER:$GROUP ~/.cache/pip/wheels
+   fi
+
+install: 
+  - pip install tox
+  - if [[ "$TRAVIS_CPU_ARCH" == "ppc64le" ]]; then pip install pytest; pip install astropy; fi
 
 script: tox


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) architecture support on travis-ci in the PR and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.
https://travis-ci.com/github/kishorkunal-raj/jdcal/builds/191730230

Reason behind running tests on ppc64le: This package is included in the ppc64le versions of RHEL and Ubuntu - this allows the top of tree to be tested continuously as it is for Intel, making it easier to catch any possible regressions on ppc64le before the distros begin their clones and builds. This reduces the work in integrating this package into future versions of RHEL/Ubuntu.

Please have a look.

Regards,
Kishor Kunal Raj
