### PR TITLE
Removing permissions on wheel as not needed anymore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,12 +55,6 @@ matrix:
     - arch: ppc64le
       python: pypy3
 
-before_install:
-  - | 
-   if [[ "$TRAVIS_CPU_ARCH" == "ppc64le" ]]; then
-     sudo chown -Rv $USER:$GROUP ~/.cache/pip/wheels
-   fi
-
 install: 
   - pip install tox
   - if [[ "$TRAVIS_CPU_ARCH" == "ppc64le" ]]; then pip install pytest; pip install astropy; fi


### PR DESCRIPTION
Hi,
In the PR, I had removed the part of granting permission to wheel directory while building it as the issue been fixed on Travis side and hence no longer needed in the travis.yml file.
Logs can be verified from : https://travis-ci.com/github/kishorkunal-raj/jdcal/builds/198230048

Regards,
Kishor Kunal Raj