### PR TITLE
Move to a declarative setuptools config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,33 @@
 [bdist_wheel]
 universal = 1
+
+[metadata]
+name = jdcal
+version = attr: jdcal.__version__
+description = Julian dates from proleptic Gregorian and Julian calendars.
+long_description = file: README.rst
+license = BSD
+author = Prasanth Nair
+author_email = prasanthhn@gmail.com
+url = https://github.com/phn/jdcal
+classifiers =
+    Development Status :: 6 - Mature
+    Intended Audience :: Science/Research
+    Operating System :: OS Independent
+    License :: OSI Approved :: BSD License
+    Topic :: Scientific/Engineering :: Astronomy
+    Programming Language :: Python
+    Programming Language :: Python :: 2
+    Programming Language :: Python :: 2.7
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.4
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: Implementation :: CPython
+    Programming Language :: Python :: Implementation :: PyPy
+
+[options]
+py_modules = jdcal

--- a/setup.py
+++ b/setup.py
@@ -2,39 +2,4 @@
 
 from setuptools import setup
 
-import jdcal
-
-version = jdcal.__version__
-
-long_description = open("README.rst").read()
-
-setup(
-    name="jdcal",
-    version=version,
-    description="Julian dates from proleptic Gregorian and Julian calendars.",
-    long_description=long_description,
-    license='BSD',
-    author="Prasanth Nair",
-    author_email="prasanthhn@gmail.com",
-    url='https://github.com/phn/jdcal',
-    classifiers=[
-        'Development Status :: 6 - Mature',
-        'Intended Audience :: Science/Research',
-        'Operating System :: OS Independent',
-        'License :: OSI Approved :: BSD License',
-        'Topic :: Scientific/Engineering :: Astronomy',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: Implementation :: CPython',
-        'Programming Language :: Python :: Implementation :: PyPy',
-    ],
-    py_modules=["jdcal"]
-)
+setup()


### PR DESCRIPTION
Avoids mixing code with configuration. For example, setuptools no longer
runs custom logic such as `open()` or `import`.

This simplifies the declaration to a list of properties and values.

For more details, see seutptools documentation:
https://setuptools.readthedocs.io/en/latest/userguide/declarative_config.html?highlight=declarative